### PR TITLE
Fix Max Feed to Grid - use runtime register 0x0700

### DIFF
--- a/custom_components/neovolt/coordinator.py
+++ b/custom_components/neovolt/coordinator.py
@@ -176,10 +176,14 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
                 # 0x08D0-0x08D1: PV Inverter Energy (scale 0.01)
                 data["pv_inverter_energy"] = self._to_unsigned_32(pv_inv_regs[0], pv_inv_regs[1]) * 0.01
 
+            # Feed to grid runtime setting (0x0700)
+            feed_to_grid_reg = self.client.read_holding_registers(0x0700, 1)
+            if feed_to_grid_reg:
+                data["max_feed_to_grid"] = feed_to_grid_reg[0]
+
             # Settings (0x0800-0x0855)
             settings_regs = self.client.read_holding_registers(0x0800, 86)
             if settings_regs:
-                data["max_feed_to_grid"] = settings_regs[0]
                 data["charging_cutoff_soc"] = settings_regs[85]
                 data["discharging_cutoff_soc"] = settings_regs[80]
                 data["time_period_control_flag"] = settings_regs[79]

--- a/custom_components/neovolt/number.py
+++ b/custom_components/neovolt/number.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
         NeovoltNumber(
             coordinator, device_info, client, hass,
             "max_feed_to_grid", "Max Feed to Grid Power",
-            0, 100, 1, PERCENTAGE, 0x0800, True
+            0, 100, 1, PERCENTAGE, 0x0700, True
         ),
         NeovoltNumber(
             coordinator, device_info, client, hass,


### PR DESCRIPTION
## Summary
- Fixed Max Feed to Grid control not curtailing solar export
- Changed from register 0x0800 (system config/global max) to 0x0700 (runtime feed-in setting)
- The runtime register actively controls grid export limiting

## Test plan
- [ ] Set Max Feed to Grid to 0% and verify solar export stops
- [ ] Set Max Feed to Grid to 50% and verify export is limited
- [ ] Verify sensor reads back the correct value after setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)