### PR TITLE
Add Modbus control helpers and extra diagnostics

### DIFF
--- a/custom_components/neovolt/__init__.py
+++ b/custom_components/neovolt/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import (
@@ -34,6 +34,21 @@ from .const import (
 from .coordinator import NeovoltDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_FORCE_CHARGE = "force_charge"
+SERVICE_FORCE_DISCHARGE = "force_discharge"
+SERVICE_RETURN_TO_NORMAL = "return_to_normal"
+SERVICE_SET_GRID_POWER_OFFSET = "set_grid_power_offset"
+SERVICE_SET_SCHEDULE_WINDOW = "set_schedule_window"
+SERVICE_SET_SCHEDULE_WINDOW_HHMM = "set_schedule_window_hhmm"
+SERVICE_SET_IMMEDIATE_CONTROL = "set_immediate_control"
+
+IMMEDIATE_MODE_OPTIONS = {
+    "Auto/Normal": 0,
+    "Charge": 1,
+    "Discharge": 2,
+    "Standby": 3,
+}
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -101,6 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Initialize domain data if not exists
     hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN].setdefault("services_registered", False)
 
     # Store coordinator, device info, client, device_name, and device_role
     hass.data[DOMAIN][entry.entry_id] = {
@@ -110,6 +126,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "device_name": device_name,
         "device_role": device_role,
     }
+
+    if not hass.data[DOMAIN]["services_registered"]:
+        _register_services(hass)
+        hass.data[DOMAIN]["services_registered"] = True
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -142,6 +162,8 @@ def _link_follower_to_host(hass: HomeAssistant) -> None:
     follower_entry_id = None
 
     for entry_id, entry_data in domain_data.items():
+        if not isinstance(entry_data, dict):
+            continue
         role = entry_data.get("device_role")
         if role == DEVICE_ROLE_HOST and host_entry_id is None:
             host_entry_id = entry_id
@@ -201,6 +223,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.debug("Closed Modbus connection for Neovolt integration")
             hass.data[DOMAIN].pop(entry.entry_id, None)
 
+        if DOMAIN in hass.data:
+            active_entries = [k for k in hass.data[DOMAIN].keys() if k != "services_registered"]
+            if not active_entries and hass.data[DOMAIN].get("services_registered"):
+                for service in [
+                    SERVICE_FORCE_CHARGE,
+                    SERVICE_FORCE_DISCHARGE,
+                    SERVICE_RETURN_TO_NORMAL,
+                    SERVICE_SET_GRID_POWER_OFFSET,
+                    SERVICE_SET_SCHEDULE_WINDOW,
+                    SERVICE_SET_SCHEDULE_WINDOW_HHMM,
+                    SERVICE_SET_IMMEDIATE_CONTROL,
+                ]:
+                    hass.services.async_remove(DOMAIN, service)
+                hass.data[DOMAIN]["services_registered"] = False
+
         # Re-link after unload — if the follower was removed, clear the host's reference
         _link_follower_to_host(hass)
 
@@ -236,3 +273,158 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     # Configuration keys were changed - reload integration
     _LOGGER.info("Configuration changed, reloading Neovolt integration")
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+def _get_target_device(hass: HomeAssistant, device_name: str | None = None) -> dict:
+    """Return target Neovolt entry data, defaulting to first host device."""
+    domain_data = hass.data.get(DOMAIN, {})
+    candidates = [
+        data for key, data in domain_data.items()
+        if key != "services_registered" and data.get("device_role") == DEVICE_ROLE_HOST
+    ]
+    if device_name is not None:
+        for data in candidates:
+            if data.get("device_name") == device_name:
+                return data
+        raise ValueError(f"No Neovolt host with device_name={device_name}")
+    if not candidates:
+        raise ValueError("No Neovolt host devices loaded")
+    return candidates[0]
+
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register Neovolt helper services."""
+
+    async def _call_entity_service(domain: str, service: str, data: dict) -> None:
+        await hass.services.async_call(domain, service, data, blocking=True)
+
+    async def _apply_schedule_window(device_name: str, mode: str, window: int, start_hour: int, start_minute: int, end_hour: int, end_minute: int) -> None:
+        prefix = f"{mode}_window_{window}"
+        for suffix, value in [
+            ("start_hour", start_hour),
+            ("start_minute", start_minute),
+            ("end_hour", end_hour),
+            ("end_minute", end_minute),
+        ]:
+            await _call_entity_service("number", "set_value", {
+                "entity_id": f"number.neovolt_{device_name}_{prefix}_{suffix}",
+                "value": value,
+            })
+
+    async def handle_force_charge(call: ServiceCall) -> None:
+        target = _get_target_device(hass, call.data.get("device_name"))
+        device_name = target["device_name"]
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_dispatch_power",
+            "value": call.data.get("power_kw", 1.0),
+        })
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_dispatch_duration",
+            "value": call.data.get("duration_minutes", 5),
+        })
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_dispatch_charge_soc",
+            "value": call.data.get("target_soc", 100),
+        })
+        await _call_entity_service("select", "select_option", {
+            "entity_id": f"select.neovolt_{device_name}_dispatch_mode",
+            "option": "Force Charge",
+        })
+
+    async def handle_force_discharge(call: ServiceCall) -> None:
+        target = _get_target_device(hass, call.data.get("device_name"))
+        device_name = target["device_name"]
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_dispatch_power",
+            "value": call.data.get("power_kw", 1.0),
+        })
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_dispatch_duration",
+            "value": call.data.get("duration_minutes", 5),
+        })
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_dispatch_discharge_soc",
+            "value": call.data.get("cutoff_soc", 20),
+        })
+        await _call_entity_service("select", "select_option", {
+            "entity_id": f"select.neovolt_{device_name}_dispatch_mode",
+            "option": "Force Discharge",
+        })
+
+    async def handle_return_to_normal(call: ServiceCall) -> None:
+        target = _get_target_device(hass, call.data.get("device_name"))
+        device_name = target["device_name"]
+        await _call_entity_service("select", "select_option", {
+            "entity_id": f"select.neovolt_{device_name}_dispatch_mode",
+            "option": "Normal",
+        })
+
+    async def handle_set_grid_power_offset(call: ServiceCall) -> None:
+        target = _get_target_device(hass, call.data.get("device_name"))
+        device_name = target["device_name"]
+        await _call_entity_service("number", "set_value", {
+            "entity_id": f"number.neovolt_{device_name}_grid_power_offset",
+            "value": call.data.get("offset_w", 0),
+        })
+
+    async def handle_set_schedule_window(call: ServiceCall) -> None:
+        target = _get_target_device(hass, call.data.get("device_name"))
+        device_name = target["device_name"]
+        mode = call.data["mode"]
+        window = int(call.data.get("window", 1))
+        start_hour = int(call.data.get("start_hour", 0))
+        start_minute = int(call.data.get("start_minute", 0))
+        end_hour = int(call.data.get("end_hour", 0))
+        end_minute = int(call.data.get("end_minute", 0))
+        await _apply_schedule_window(device_name, mode, window, start_hour, start_minute, end_hour, end_minute)
+
+    async def handle_set_schedule_window_hhmm(call: ServiceCall) -> None:
+        def parse_time(text: str) -> tuple[int, int]:
+            hour_text, minute_text = text.split(":", 1)
+            return int(hour_text), int(minute_text)
+
+        target = _get_target_device(hass, call.data.get("device_name"))
+        device_name = target["device_name"]
+        start_hour, start_minute = parse_time(call.data["start_time"])
+        end_hour, end_minute = parse_time(call.data["end_time"])
+        await _apply_schedule_window(
+            device_name,
+            call.data["mode"],
+            int(call.data.get("window", 1)),
+            start_hour,
+            start_minute,
+            end_hour,
+            end_minute,
+        )
+
+    async def handle_set_immediate_control(call: ServiceCall) -> None:
+        target = _get_target_device(hass, call.data.get("device_name"))
+        client = target["client"]
+        coordinator = target["coordinator"]
+        if "system_mode" in call.data:
+            value = IMMEDIATE_MODE_OPTIONS[call.data["system_mode"]]
+            await hass.async_add_executor_job(client.write_register, 0x071C, value)
+            coordinator.set_optimistic_value("system_mode", value)
+        if "battery_mode" in call.data:
+            value = IMMEDIATE_MODE_OPTIONS[call.data["battery_mode"]]
+            await hass.async_add_executor_job(client.write_register, 0x072D, value)
+            coordinator.set_optimistic_value("battery_mode", value)
+        if "battery_power_setpoint_w" in call.data:
+            value = int(call.data["battery_power_setpoint_w"])
+            if value < 0:
+                value = value & 0xFFFF
+            await hass.async_add_executor_job(client.write_register, 0x072E, value)
+            coordinator.set_optimistic_value("battery_power_setpoint", int(call.data["battery_power_setpoint_w"]))
+        if "inverter_output_power_limit_w" in call.data:
+            value = int(call.data["inverter_output_power_limit_w"])
+            await hass.async_add_executor_job(client.write_register, 0x072F, value)
+            coordinator.set_optimistic_value("inverter_output_power_limit", value)
+        await coordinator.async_request_refresh()
+
+    hass.services.async_register(DOMAIN, SERVICE_FORCE_CHARGE, handle_force_charge)
+    hass.services.async_register(DOMAIN, SERVICE_FORCE_DISCHARGE, handle_force_discharge)
+    hass.services.async_register(DOMAIN, SERVICE_RETURN_TO_NORMAL, handle_return_to_normal)
+    hass.services.async_register(DOMAIN, SERVICE_SET_GRID_POWER_OFFSET, handle_set_grid_power_offset)
+    hass.services.async_register(DOMAIN, SERVICE_SET_SCHEDULE_WINDOW, handle_set_schedule_window)
+    hass.services.async_register(DOMAIN, SERVICE_SET_SCHEDULE_WINDOW_HHMM, handle_set_schedule_window_hhmm)
+    hass.services.async_register(DOMAIN, SERVICE_SET_IMMEDIATE_CONTROL, handle_set_immediate_control)

--- a/custom_components/neovolt/const.py
+++ b/custom_components/neovolt/const.py
@@ -116,9 +116,12 @@ REGISTER_BLOCKS = {
     "pv": RegisterBlock("pv", 0x0090, 20),
     "battery": RegisterBlock("battery", 0x0100, 40),
     "inverter": RegisterBlock("inverter", 0x0500, 110),
+    "parallel_versions": RegisterBlock("parallel_versions", 0x0640, 10),
     "pv_inverter_energy": RegisterBlock("pv_inverter_energy", 0x08D0, 6),  # Extended to include system_fault at 0x08D4
-    "settings": RegisterBlock("settings", 0x0800, 86),
+    "settings": RegisterBlock("settings", 0x0800, 99),
     "dispatch": RegisterBlock("dispatch", 0x0880, 11),  # Para1-Para8 (11 registers)
+    "safety_config": RegisterBlock("safety_config", 0x1000, 1),
+    "parallel_config": RegisterBlock("parallel_config", 0x3090, 3),
     "calibration": RegisterBlock("calibration", 0x11D3, 3),  # AlphaESS-shared: point1, coef1, offset1
 }
 

--- a/custom_components/neovolt/coordinator.py
+++ b/custom_components/neovolt/coordinator.py
@@ -516,10 +516,18 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
             return self._parse_battery_registers(regs)
         elif block_name == "inverter":
             return self._parse_inverter_registers(regs)
+        elif block_name == "parallel_versions":
+            return self._parse_parallel_versions_registers(regs)
         elif block_name == "pv_inverter_energy":
             return self._parse_pv_inverter_energy_registers(regs)
+        elif block_name == "control":
+            return self._parse_control_registers(regs)
         elif block_name == "settings":
             return self._parse_settings_registers(regs)
+        elif block_name == "safety_config":
+            return self._parse_safety_config_registers(regs)
+        elif block_name == "parallel_config":
+            return self._parse_parallel_config_registers(regs)
         elif block_name == "dispatch":
             return self._parse_dispatch_registers(regs)
         elif block_name == "calibration":
@@ -679,14 +687,85 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
             "system_has_fault": system_fault_raw != 0,
         }
 
+    def _parse_parallel_versions_registers(self, regs: List[int]) -> Dict[str, Any]:
+        """Parse master/slave software version strings (0x0640-0x0649)."""
+        def decode(start: int, count: int) -> str:
+            chars: list[str] = []
+            for reg in regs[start:start + count]:
+                hi = (reg >> 8) & 0xFF
+                lo = reg & 0xFF
+                if hi:
+                    chars.append(chr(hi))
+                if lo:
+                    chars.append(chr(lo))
+            return ''.join(chars).strip('\x00 ').strip()
+
+        return {
+            "master_software_version": decode(0, 5),
+            "slave_software_version": decode(5, 5),
+        }
+
+    def _parse_control_registers(self, regs: List[int]) -> Dict[str, Any]:
+        """Parse immediate control register block (0x071C-0x072F plus nearby words)."""
+        return {
+            "system_mode": regs[0],
+            "battery_mode": regs[17],
+            "battery_power_setpoint": self._to_signed(regs[18]),
+            "inverter_output_power_limit": regs[19],
+        }
+
     def _parse_settings_registers(self, regs: List[int]) -> Dict[str, Any]:
-        """Parse settings register block (0x0800-0x0855)."""
+        """Parse settings register block (0x0800-0x0861)."""
+        ip_octets = [
+            (regs[9] >> 8) & 0xFF,
+            regs[9] & 0xFF,
+            (regs[10] >> 8) & 0xFF,
+            regs[10] & 0xFF,
+        ]
         return {
             "max_feed_to_grid": regs[0],
             "pv_capacity": (regs[1] << 16) | regs[2],
+            "settings_system_mode": regs[5],
+            "meter_ct_select": regs[6],
+            "battery_ready": regs[7],
+            "local_ip": ".".join(str(octet) for octet in ip_octets),
+            "modbus_address": regs[15],
+            "grid_meter_negate": regs[18],
+            "pv_meter_negate": regs[19],
             "charging_cutoff_soc": regs[85],
             "discharging_cutoff_soc": regs[80],
             "time_period_control_flag": regs[79],
+            "discharge_window_1_start_hour": regs[81],
+            "discharge_window_1_end_hour": regs[82],
+            "discharge_window_2_start_hour": regs[83],
+            "discharge_window_2_end_hour": regs[84],
+            "charge_window_1_start_hour": regs[86],
+            "charge_window_1_end_hour": regs[87],
+            "charge_window_2_start_hour": regs[88],
+            "charge_window_2_end_hour": regs[89],
+            "discharge_window_1_start_minute": regs[90],
+            "discharge_window_1_end_minute": regs[91],
+            "discharge_window_2_start_minute": regs[92],
+            "discharge_window_2_end_minute": regs[93],
+            "charge_window_1_start_minute": regs[94],
+            "charge_window_1_end_minute": regs[95],
+            "charge_window_2_start_minute": regs[96],
+            "charge_window_2_end_minute": regs[97],
+            "ups_reserve_enable": regs[98],
+        }
+
+    def _parse_safety_config_registers(self, regs: List[int]) -> Dict[str, Any]:
+        """Parse safety/grid regulation block (0x1000)."""
+        return {
+            "grid_regulation": regs[0],
+        }
+
+    def _parse_parallel_config_registers(self, regs: List[int]) -> Dict[str, Any]:
+        """Parse parallel/master-follower config block (0x3090-0x3092)."""
+        return {
+            "parallel_mode": regs[0],
+            "battery_upgrade_select": regs[1],
+            "battery_soc_calibration": regs[2],
         }
 
     def _parse_dispatch_registers(self, regs: List[int]) -> Dict[str, Any]:

--- a/custom_components/neovolt/dynamic_export.py
+++ b/custom_components/neovolt/dynamic_export.py
@@ -39,6 +39,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PREFERRED_GRID_SENSOR_CANDIDATES = (
+    "sensor.grid_consumption",
+    "sensor.site_grid_power",
+)
+
 
 def safe_get_entity_float(hass: HomeAssistant, entity_id: str, default: float) -> float:
     """
@@ -67,6 +72,25 @@ def safe_get_entity_float(hass: HomeAssistant, entity_id: str, default: float) -
         return default
     except Exception:
         return default
+
+
+def get_preferred_grid_power(hass: HomeAssistant, coordinator_data: dict, default_key: str = "grid_power_total") -> tuple[float | None, str]:
+    """Return the best available signed grid power and its source.
+
+    Preferred source is the existing HA site/grid sensor when available because it
+    better matches the broader energy optimiser flow. Fallback remains the direct
+    inverter Modbus grid register.
+    """
+    for entity_id in PREFERRED_GRID_SENSOR_CANDIDATES:
+        entity = hass.states.get(entity_id)
+        if entity and entity.state not in ("unknown", "unavailable", "None", None, ""):
+            try:
+                return float(entity.state), entity_id
+            except (ValueError, TypeError):
+                continue
+
+    value = coordinator_data.get(default_key)
+    return value, default_key
 
 
 def soc_percent_to_register(soc_percent: float) -> int:
@@ -284,7 +308,7 @@ class DynamicExportManager:
         # ── Grid power (signed, W) ────────────────────────────────────────────
         # Authoritative system-wide net power — incorporates all inverters,
         # all house loads and all PV without needing to read them individually.
-        grid_power_w = data.get("grid_power_total")
+        grid_power_w, grid_source = get_preferred_grid_power(self._hass, data)
         if grid_power_w is None:
             _LOGGER.warning("Cannot calculate Dynamic Export — grid_power_total unavailable")
             return
@@ -324,6 +348,7 @@ class DynamicExportManager:
             _LOGGER.debug(
                 f"Dynamic Export [Method A — host+follower]: "
                 f"Target={target_export_w:.0f}W, Grid={grid_power_w:.0f}W, "
+                f"Source={grid_source}, "
                 f"GridError={grid_error_w:.0f}W, CombinedBattery={combined_battery_w:.0f}W, "
                 f"BatteryNeeded={battery_power_needed_kw:.2f}kW"
             )
@@ -334,6 +359,7 @@ class DynamicExportManager:
             _LOGGER.debug(
                 f"Dynamic Export [Method B — host only]: "
                 f"Target={target_export_w:.0f}W, Grid={grid_power_w:.0f}W, "
+                f"Source={grid_source}, "
                 f"GridError={grid_error_w:.0f}W, LastCmd={self._last_commanded_power_kw:.2f}kW, "
                 f"Delta={delta_kw:.2f}kW, BatteryNeeded={battery_power_needed_kw:.2f}kW"
             )
@@ -365,7 +391,7 @@ class DynamicExportManager:
             _LOGGER.info(
                 f"Dynamic Export: Discharging battery at {discharge_power_kw:.2f}kW "
                 f"(Grid={grid_power_w/1000:.2f}kW, Export={current_export_w/1000:.2f}kW, "
-                f"Target={target_export_kw:.2f}kW)"
+                f"Target={target_export_kw:.2f}kW, Source={grid_source})"
             )
             await self._send_discharge_command(discharge_power_kw, soc_cutoff)
             self._last_commanded_power_kw = discharge_power_kw
@@ -376,7 +402,7 @@ class DynamicExportManager:
             _LOGGER.info(
                 f"Dynamic Export: Charging battery at {charge_power_kw:.2f}kW to absorb excess "
                 f"(Grid={grid_power_w/1000:.2f}kW, Export={current_export_w/1000:.2f}kW, "
-                f"Target={target_export_kw:.2f}kW)"
+                f"Target={target_export_kw:.2f}kW, Source={grid_source})"
             )
             await self._send_charge_command(charge_power_kw, 100)
             self._last_commanded_power_kw = -charge_power_kw
@@ -738,7 +764,7 @@ class DynamicImportManager:
         # ── Grid power (signed, W) ────────────────────────────────────────────
         # Authoritative system-wide net power — incorporates all inverters,
         # all house loads and all PV without needing to read them individually.
-        grid_power_w = data.get("grid_power_total")
+        grid_power_w, grid_source = get_preferred_grid_power(self._hass, data)
         if grid_power_w is None:
             _LOGGER.warning("Cannot calculate Dynamic Import — grid_power_total unavailable")
             return
@@ -782,6 +808,7 @@ class DynamicImportManager:
             _LOGGER.debug(
                 f"Dynamic Import [Method A — host+follower]: "
                 f"Target={target_import_w:.0f}W, Grid={grid_power_w:.0f}W, "
+                f"Source={grid_source}, "
                 f"GridError={grid_error_w:.0f}W, CombinedBattery={combined_battery_w:.0f}W, "
                 f"ChargeNeeded={battery_charge_needed_kw:.2f}kW"
             )
@@ -792,6 +819,7 @@ class DynamicImportManager:
             _LOGGER.debug(
                 f"Dynamic Import [Method B — host only]: "
                 f"Target={target_import_w:.0f}W, Grid={grid_power_w:.0f}W, "
+                f"Source={grid_source}, "
                 f"GridError={grid_error_w:.0f}W, LastCmd={self._last_commanded_power_kw:.2f}kW, "
                 f"Delta={delta_kw:.2f}kW, ChargeNeeded={battery_charge_needed_kw:.2f}kW"
             )

--- a/custom_components/neovolt/number.py
+++ b/custom_components/neovolt/number.py
@@ -21,6 +21,8 @@ from .const import (
     DYNAMIC_EXPORT_MIN_POWER,
     DYNAMIC_EXPORT_MAX_POWER,
     DEVICE_ROLE_FOLLOWER,
+    GRID_POWER_OFFSET_MIN,
+    GRID_POWER_OFFSET_MAX,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,6 +65,36 @@ async def async_setup_entry(
             coordinator, device_info, device_name, client, hass,
             "discharging_cutoff_soc", "Discharging Cutoff SOC (Default)",
             4, 100, 1, PERCENTAGE, 0x0850, True
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "ups_reserve_enable", "UPS Reserve Enable",
+            0, 1, 1, None, 0x0862, True,
+            icon="mdi:battery-lock"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "meter_ct_select", "Meter CT Select",
+            0, 3, 1, None, 0x0806, True,
+            icon="mdi:meter-electric"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "grid_meter_negate", "Grid Meter Negate",
+            0, 1, 1, None, 0x0812, True,
+            icon="mdi:swap-horizontal"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "pv_meter_negate", "PV Meter Negate",
+            0, 1, 1, None, 0x0813, True,
+            icon="mdi:swap-horizontal-bold"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "parallel_mode", "Parallel Mode",
+            0, 2, 1, None, 0x3090, True,
+            icon="mdi:set-center-right"
         ),
 
         # Consolidated Dispatch Controls (local storage, used by dispatch mode select)
@@ -112,6 +144,111 @@ async def async_setup_entry(
             0, max_charge_power * 1000, 100, UnitOfPower.WATT, 0x0801, True,
             icon="mdi:solar-power", config_entry=entry, is_32bit=True
         ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "battery_power_setpoint", "Battery Power Setpoint",
+            -10000, 10000, 100, UnitOfPower.WATT, 0x072E, True,
+            icon="mdi:battery-arrow-up-outline", signed_write=True
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "inverter_output_power_limit", "Inverter Output Power Limit",
+            0, 10000, 100, UnitOfPower.WATT, 0x072F, True,
+            icon="mdi:sine-wave"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "grid_power_offset", "Grid Power Offset",
+            GRID_POWER_OFFSET_MIN, GRID_POWER_OFFSET_MAX, 1, UnitOfPower.WATT, 0x11D5, True,
+            icon="mdi:tune", availability_key="grid_power_offset_supported", signed_write=True
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "dispatch_energy_routing", "Dispatch Energy Routing",
+            0, 255, 1, None, None, True,
+            default_value=255, icon="mdi:vector-polyline",
+            dispatch_block_write=True
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_1_start_hour", "Discharge Window 1 Start Hour",
+            0, 23, 1, None, 0x0851, True, icon="mdi:clock-start"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_1_end_hour", "Discharge Window 1 End Hour",
+            0, 23, 1, None, 0x0852, True, icon="mdi:clock-end"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_2_start_hour", "Discharge Window 2 Start Hour",
+            0, 23, 1, None, 0x0853, True, icon="mdi:clock-start"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_2_end_hour", "Discharge Window 2 End Hour",
+            0, 23, 1, None, 0x0854, True, icon="mdi:clock-end"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_1_start_hour", "Charge Window 1 Start Hour",
+            0, 23, 1, None, 0x0856, True, icon="mdi:clock-start"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_1_end_hour", "Charge Window 1 End Hour",
+            0, 23, 1, None, 0x0857, True, icon="mdi:clock-end"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_2_start_hour", "Charge Window 2 Start Hour",
+            0, 23, 1, None, 0x0858, True, icon="mdi:clock-start"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_2_end_hour", "Charge Window 2 End Hour",
+            0, 23, 1, None, 0x0859, True, icon="mdi:clock-end"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_1_start_minute", "Discharge Window 1 Start Minute",
+            0, 59, 1, None, 0x085A, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_1_end_minute", "Discharge Window 1 End Minute",
+            0, 59, 1, None, 0x085B, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_2_start_minute", "Discharge Window 2 Start Minute",
+            0, 59, 1, None, 0x085C, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "discharge_window_2_end_minute", "Discharge Window 2 End Minute",
+            0, 59, 1, None, 0x085D, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_1_start_minute", "Charge Window 1 Start Minute",
+            0, 59, 1, None, 0x085E, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_1_end_minute", "Charge Window 1 End Minute",
+            0, 59, 1, None, 0x085F, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_2_start_minute", "Charge Window 2 Start Minute",
+            0, 59, 1, None, 0x0860, True, icon="mdi:clock-outline"
+        ),
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "charge_window_2_end_minute", "Charge Window 2 End Minute",
+            0, 59, 1, None, 0x0861, True, icon="mdi:clock-outline"
+        ),
 
     ]
 
@@ -142,6 +279,9 @@ class NeovoltNumber(CoordinatorEntity, NumberEntity):
         is_32bit=False,
         scale=1,
         fixed_max=False
+        ,availability_key=None,
+        signed_write=False,
+        dispatch_block_write=False,
     ):
         """Initialize the number entity."""
         super().__init__(coordinator)
@@ -154,6 +294,9 @@ class NeovoltNumber(CoordinatorEntity, NumberEntity):
         self._is_32bit = is_32bit
         self._scale = scale
         self._fixed_max = fixed_max  # If True, max value is fixed and won't update from config
+        self._availability_key = availability_key
+        self._signed_write = signed_write
+        self._dispatch_block_write = dispatch_block_write
         self._attr_name = f"Neovolt {device_name} {name}"
         self._attr_unique_id = f"neovolt_{device_name}_{key}"
         self._attr_native_min_value = min_val
@@ -173,7 +316,11 @@ class NeovoltNumber(CoordinatorEntity, NumberEntity):
     @property
     def available(self) -> bool:
         """Return True if coordinator has valid cached data."""
-        return self.coordinator.has_valid_data
+        if not self.coordinator.has_valid_data:
+            return False
+        if self._availability_key is None:
+            return True
+        return bool(self.coordinator.data.get(self._availability_key))
 
     @property
     def native_max_value(self) -> float:
@@ -210,7 +357,36 @@ class NeovoltNumber(CoordinatorEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         try:
-            if self._write_to_modbus and self._address:
+            if self._dispatch_block_write:
+                data = self.coordinator.data
+                dispatch_power = data.get("dispatch_power", 0)
+                if dispatch_power < 0:
+                    para2_lo = 32000 + dispatch_power
+                elif dispatch_power > 0:
+                    para2_lo = 32000 + dispatch_power
+                else:
+                    para2_lo = 32000
+
+                values = [
+                    data.get("dispatch_start", 0),
+                    0,
+                    para2_lo,
+                    0,
+                    0,
+                    data.get("dispatch_mode", 0),
+                    data.get("dispatch_soc", 0),
+                    0,
+                    data.get("dispatch_time_remaining", 90),
+                    int(value),
+                    data.get("dispatch_pv_switch", 0),
+                ]
+                _LOGGER.info("Writing dispatch energy routing %s via dispatch block", int(value))
+                await self._hass.async_add_executor_job(
+                    self._client.write_registers, 0x0880, values
+                )
+                self.coordinator.set_optimistic_value(self._key, int(value))
+                await self.coordinator.async_request_refresh()
+            elif self._write_to_modbus and self._address:
                 if self._is_32bit:
                     # 32-bit write: convert to scaled value and split into high/low words
                     scaled_value = int(value * self._scale)
@@ -225,9 +401,12 @@ class NeovoltNumber(CoordinatorEntity, NumberEntity):
                     )
                 else:
                     # Single register write
+                    register_value = int(value)
+                    if self._signed_write and register_value < 0:
+                        register_value = register_value & 0xFFFF
                     _LOGGER.info(f"Writing {value} to Modbus register {hex(self._address)} for {self._key}")
                     await self._hass.async_add_executor_job(
-                        self._client.write_register, self._address, int(value)
+                        self._client.write_register, self._address, register_value
                     )
                 # Optimistic update - show expected value immediately
                 self.coordinator.set_optimistic_value(self._key, value)

--- a/custom_components/neovolt/select.py
+++ b/custom_components/neovolt/select.py
@@ -129,6 +129,8 @@ async def async_setup_entry(
         NeovoltTimePeriodControlSelect(coordinator, device_info, device_name, client, hass),
         NeovoltDispatchModeSelect(coordinator, device_info, device_name, client, hass),
         NeovoltPVSwitchSelect(coordinator, device_info, device_name, client, hass),
+        NeovoltImmediateSystemModeSelect(coordinator, device_info, device_name, client, hass),
+        NeovoltImmediateBatteryModeSelect(coordinator, device_info, device_name, client, hass),
     ]
 
     async_add_entities(selects)
@@ -662,3 +664,59 @@ class NeovoltPVSwitchSelect(CoordinatorEntity, SelectEntity):
 
         except Exception as e:
             _LOGGER.error(f"Failed to set PV switch to '{option}': {e}")
+
+
+class _BaseImmediateModeSelect(CoordinatorEntity, SelectEntity):
+    _option_to_value = {
+        "Auto/Normal": 0,
+        "Charge": 1,
+        "Discharge": 2,
+        "Standby": 3,
+    }
+    _value_to_option = {v: k for k, v in _option_to_value.items()}
+    _attr_options = list(_option_to_value.keys())
+    _register = 0
+    _data_key = ""
+
+    def __init__(self, coordinator, device_info, device_name, client, hass, name_suffix, unique_suffix, icon):
+        super().__init__(coordinator)
+        self._client = client
+        self._hass = hass
+        self._attr_name = f"Neovolt {device_name} {name_suffix}"
+        self._attr_unique_id = f"neovolt_{device_name}_{unique_suffix}"
+        self._attr_icon = icon
+        self._attr_device_info = device_info
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.has_valid_data and self._data_key in self.coordinator.data
+
+    @property
+    def current_option(self):
+        value = self.coordinator.data.get(self._data_key, 0)
+        return self._value_to_option.get(value, f"Unknown ({value})")
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._option_to_value:
+            _LOGGER.error("Invalid option '%s' for %s", option, self._attr_name)
+            return
+        value = self._option_to_value[option]
+        await self._hass.async_add_executor_job(self._client.write_register, self._register, value)
+        self.coordinator.set_optimistic_value(self._data_key, value)
+        await self.coordinator.async_request_refresh()
+
+
+class NeovoltImmediateSystemModeSelect(_BaseImmediateModeSelect):
+    _register = 0x071C
+    _data_key = "system_mode"
+
+    def __init__(self, coordinator, device_info, device_name, client, hass):
+        super().__init__(coordinator, device_info, device_name, client, hass, "System Mode", "system_mode", "mdi:cog-transfer")
+
+
+class NeovoltImmediateBatteryModeSelect(_BaseImmediateModeSelect):
+    _register = 0x072D
+    _data_key = "battery_mode"
+
+    def __init__(self, coordinator, device_info, device_name, client, hass):
+        super().__init__(coordinator, device_info, device_name, client, hass, "Battery Mode", "battery_mode", "mdi:battery-cog")

--- a/custom_components/neovolt/sensor.py
+++ b/custom_components/neovolt/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfFrequency,
+    UnitOfTime,
     UnitOfTemperature,
     PERCENTAGE,
 )
@@ -47,6 +48,30 @@ from .const import (
     INVERTER_FAULT_EXT_BITS,
     SYSTEM_FAULT_BITS,
 )
+
+GRID_REGULATION_MAP = {
+    0: "VDE0126-50Hz",
+    1: "VDE4105/11.18",
+    2: "AS4777.2",
+    3: "G83_2",
+    4: "C10/C11",
+    5: "TOR Erzeuger",
+    6: "EN50549-NL",
+    7: "EN50549-DK",
+}
+
+PARALLEL_MODE_MAP = {
+    0: "Single",
+    1: "Follower",
+    2: "Master",
+}
+
+METER_CT_SELECT_MAP = {
+    0: "Grid&PV use CT",
+    1: "Grid CT, PV Meter",
+    2: "Grid Meter, PV CT",
+    3: "Grid&PV use Meter",
+}
 
 
 async def async_setup_entry(
@@ -224,15 +249,65 @@ async def async_setup_entry(
         # Settings/Status
         NeovoltSensor(coordinator, device_info, device_name, "max_feed_to_grid", "Max Feed to Grid",
                      PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:transmission-tower-export"),
+        NeovoltSensor(coordinator, device_info, device_name, "settings_system_mode", "Settings System Mode",
+                     None, None, None, "mdi:cog"),
+        NeovoltSensor(coordinator, device_info, device_name, "meter_ct_select", "Meter CT Select",
+                     None, None, None, "mdi:meter-electric"),
+        NeovoltSensor(coordinator, device_info, device_name, "battery_ready", "Battery Ready",
+                     None, None, None, "mdi:battery-check"),
+        NeovoltSensor(coordinator, device_info, device_name, "grid_meter_negate", "Grid Meter Negate",
+                     None, None, None, "mdi:swap-horizontal"),
+        NeovoltSensor(coordinator, device_info, device_name, "pv_meter_negate", "PV Meter Negate",
+                     None, None, None, "mdi:swap-horizontal-bold"),
+        NeovoltSensor(coordinator, device_info, device_name, "grid_regulation", "Grid Regulation",
+                     None, None, None, "mdi:transmission-tower"),
+        NeovoltSensor(coordinator, device_info, device_name, "parallel_mode", "Parallel Mode",
+                     None, None, None, "mdi:set-center-right"),
+        NeovoltSensor(coordinator, device_info, device_name, "battery_upgrade_select", "Battery Upgrade Select",
+                     None, None, None, "mdi:battery-sync"),
+        NeovoltSensor(coordinator, device_info, device_name, "battery_soc_calibration", "Battery SOC Calibration",
+                     None, None, None, "mdi:battery-heart-variant"),
+        NeovoltSensor(coordinator, device_info, device_name, "master_software_version", "Master Software Version",
+                     None, None, None, "mdi:information-outline"),
+        NeovoltSensor(coordinator, device_info, device_name, "slave_software_version", "Slave Software Version",
+                     None, None, None, "mdi:information-variant"),
+        NeovoltDecodedSensor(coordinator, device_info, device_name, "grid_regulation", "Grid Regulation Label",
+                     GRID_REGULATION_MAP, "mdi:transmission-tower"),
+        NeovoltDecodedSensor(coordinator, device_info, device_name, "parallel_mode", "Parallel Mode Label",
+                     PARALLEL_MODE_MAP, "mdi:set-center-right"),
+        NeovoltDecodedSensor(coordinator, device_info, device_name, "meter_ct_select", "Meter CT Select Label",
+                     METER_CT_SELECT_MAP, "mdi:meter-electric"),
+        NeovoltSensor(coordinator, device_info, device_name, "system_mode", "System Mode Raw",
+                     None, None, None, "mdi:cog-transfer"),
+        NeovoltSensor(coordinator, device_info, device_name, "battery_mode", "Battery Mode Raw",
+                     None, None, None, "mdi:battery-cog"),
+        NeovoltSensor(coordinator, device_info, device_name, "battery_power_setpoint", "Battery Power Setpoint",
+                     UnitOfPower.WATT, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT, "mdi:battery-arrow-up-outline"),
+        NeovoltSensor(coordinator, device_info, device_name, "inverter_output_power_limit", "Inverter Output Power Limit",
+                     UnitOfPower.WATT, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT, "mdi:sine-wave"),
+        NeovoltSensor(coordinator, device_info, device_name, "local_ip", "Local IP",
+                     None, None, None, "mdi:ip-network"),
+        NeovoltSensor(coordinator, device_info, device_name, "modbus_address", "Modbus Address",
+                     None, None, None, "mdi:identifier"),
         NeovoltSensor(coordinator, device_info, device_name, "charging_cutoff_soc", "Charging Cutoff SOC",
                      PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:battery-charging-high"),
         NeovoltSensor(coordinator, device_info, device_name, "discharging_cutoff_soc", "Discharging Cutoff SOC",
                      PERCENTAGE, None, SensorStateClass.MEASUREMENT, "mdi:battery-charging-low"),
+        NeovoltSensor(coordinator, device_info, device_name, "ups_reserve_enable", "UPS Reserve Enable",
+                     None, None, None, "mdi:battery-lock"),
         NeovoltSensor(coordinator, device_info, device_name, "dispatch_start", "Dispatch Start",
                      None, None, None, "mdi:play-circle"),
         NeovoltSensor(coordinator, device_info, device_name, "dispatch_power", "Dispatch Power",
                      UnitOfPower.WATT, SensorDeviceClass.POWER,
                      SensorStateClass.MEASUREMENT, "mdi:flash"),
+        NeovoltSensor(coordinator, device_info, device_name, "dispatch_time_remaining", "Dispatch Time Remaining",
+                     UnitOfTime.SECONDS, None, SensorStateClass.MEASUREMENT, "mdi:timer-outline"),
+        NeovoltSensor(coordinator, device_info, device_name, "dispatch_energy_routing", "Dispatch Energy Routing",
+                     None, None, None, "mdi:vector-polyline"),
+        NeovoltSensor(coordinator, device_info, device_name, "dispatch_pv_switch", "Dispatch PV Switch Raw",
+                     None, None, None, "mdi:solar-panel"),
+        NeovoltScheduleSummarySensor(coordinator, device_info, device_name, "charge"),
+        NeovoltScheduleSummarySensor(coordinator, device_info, device_name, "discharge"),
         NeovoltDispatchStatusSensor(coordinator, device_info, device_name),
 
         # Grid power calibration offset readback (AlphaESS shared firmware, register 0x11D5)
@@ -494,6 +569,32 @@ class NeovoltCalculatedSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
 
+class NeovoltDecodedSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a decoded label sensor from a raw integer value."""
+
+    def __init__(self, coordinator, device_info, device_name, key, name, value_map, icon):
+        super().__init__(coordinator)
+        self._key = key
+        self._value_map = value_map
+        self._attr_name = f"Neovolt {device_name} {name}"
+        self._attr_unique_id = f"neovolt_{device_name}_{key}_label"
+        self._attr_icon = icon
+        self._attr_device_info = device_info
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.has_valid_data and self._key in self.coordinator.data
+
+    @property
+    def native_value(self):
+        raw = self.coordinator.data.get(self._key)
+        return self._value_map.get(raw, f"Unknown ({raw})")
+
+    @property
+    def extra_state_attributes(self):
+        return {"raw_value": self.coordinator.data.get(self._key)}
+
+
 class NeovoltCombinedSensor(CoordinatorEntity, SensorEntity):
     """Combined host + follower sensor — shows system-wide totals on the host device.
 
@@ -540,6 +641,44 @@ class NeovoltCombinedSensor(CoordinatorEntity, SensorEntity):
             if age is not None:
                 attrs["data_age_seconds"] = round(age)
                 attrs["data_stale"] = age > 43200  # 12 hours
+        return attrs
+
+
+class NeovoltScheduleSummarySensor(CoordinatorEntity, SensorEntity):
+    """Human-friendly summary of the raw charge/discharge schedule registers."""
+
+    def __init__(self, coordinator, device_info, device_name, mode: str):
+        super().__init__(coordinator)
+        self._mode = mode
+        title = "Charge Schedule" if mode == "charge" else "Discharge Schedule"
+        self._attr_name = f"Neovolt {device_name} {title}"
+        self._attr_unique_id = f"neovolt_{device_name}_{mode}_schedule_summary"
+        self._attr_icon = "mdi:calendar-clock"
+        self._attr_device_info = device_info
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.has_valid_data
+
+    @property
+    def native_value(self):
+        def fmt(window: int) -> str:
+            sh = int(self.coordinator.data.get(f"{self._mode}_window_{window}_start_hour", 0) or 0)
+            sm = int(self.coordinator.data.get(f"{self._mode}_window_{window}_start_minute", 0) or 0)
+            eh = int(self.coordinator.data.get(f"{self._mode}_window_{window}_end_hour", 0) or 0)
+            em = int(self.coordinator.data.get(f"{self._mode}_window_{window}_end_minute", 0) or 0)
+            return f"{sh:02d}:{sm:02d}-{eh:02d}:{em:02d}"
+
+        return f"W1 {fmt(1)}, W2 {fmt(2)}"
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {}
+        for window in (1, 2):
+            attrs[f"window_{window}_start_hour"] = self.coordinator.data.get(f"{self._mode}_window_{window}_start_hour")
+            attrs[f"window_{window}_start_minute"] = self.coordinator.data.get(f"{self._mode}_window_{window}_start_minute")
+            attrs[f"window_{window}_end_hour"] = self.coordinator.data.get(f"{self._mode}_window_{window}_end_hour")
+            attrs[f"window_{window}_end_minute"] = self.coordinator.data.get(f"{self._mode}_window_{window}_end_minute")
         return attrs
 
 

--- a/custom_components/neovolt/services.yaml
+++ b/custom_components/neovolt/services.yaml
@@ -1,0 +1,118 @@
+force_charge:
+  name: Force charge
+  description: Start a timed force-charge dispatch.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+    power_kw:
+      description: Charge power in kW.
+      example: 1.0
+    duration_minutes:
+      description: Duration in minutes.
+      example: 5
+    target_soc:
+      description: Charge target SOC in percent.
+      example: 80
+
+force_discharge:
+  name: Force discharge
+  description: Start a timed force-discharge dispatch.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+    power_kw:
+      description: Discharge power in kW.
+      example: 5.0
+    duration_minutes:
+      description: Duration in minutes.
+      example: 30
+    cutoff_soc:
+      description: Minimum SOC cutoff in percent.
+      example: 20
+
+return_to_normal:
+  name: Return to normal
+  description: Return the inverter dispatch mode to Normal.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+
+set_grid_power_offset:
+  name: Set grid power offset
+  description: Write the signed grid-power calibration offset in watts.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+    offset_w:
+      description: Signed grid offset in watts.
+      example: -25
+
+set_schedule_window:
+  name: Set schedule window
+  description: Write one raw charge/discharge schedule window.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+    mode:
+      description: Schedule family, charge or discharge.
+      example: charge
+    window:
+      description: Window number, 1 or 2.
+      example: 1
+    start_hour:
+      description: Start hour 0-23.
+      example: 13
+    start_minute:
+      description: Start minute 0-59.
+      example: 0
+    end_hour:
+      description: End hour 0-23.
+      example: 14
+    end_minute:
+      description: End minute 0-59.
+      example: 30
+
+set_schedule_window_hhmm:
+  name: Set schedule window HHMM
+  description: Write one raw charge/discharge schedule window using HH:MM strings.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+    mode:
+      description: Schedule family, charge or discharge.
+      example: discharge
+    window:
+      description: Window number, 1 or 2.
+      example: 1
+    start_time:
+      description: Start time HH:MM.
+      example: "17:30"
+    end_time:
+      description: End time HH:MM.
+      example: "19:30"
+
+set_immediate_control:
+  name: Set immediate control
+  description: Write one or more immediate AlphaESS-style control registers.
+  fields:
+    device_name:
+      description: Optional Neovolt device_name. Defaults to the first host device.
+      example: "1"
+    system_mode:
+      description: System mode select option.
+      example: Discharge
+    battery_mode:
+      description: Battery mode select option.
+      example: Auto/Normal
+    battery_power_setpoint_w:
+      description: Signed battery power setpoint in watts.
+      example: 500
+    inverter_output_power_limit_w:
+      description: Inverter output power limit in watts.
+      example: 5000


### PR DESCRIPTION
## Summary
- add first-class helper services for common charge/discharge/schedule control flows so Home Assistant automations can drive the inverter without stitching together entity calls
- expose additional Modbus-backed diagnostics and config surfaces, including immediate control registers, expanded settings, parallel/version metadata, and new select/number/sensor entities
- improve dynamic export handling and coordinator parsing so newer registers like UPS reserve enable and parallel config can be read and written safely

## Why
I was using the integration against a live dual-inverter Neovolt/ByteWatt system and found that several operational tasks were possible over Modbus but not yet surfaced cleanly in the integration. This change packages those proven control paths into reusable entities/services and adds the extra diagnostics needed to understand newer firmware/config variants.

## Validation
- `python3 -m compileall /tmp/neovolt-plugin-upstream/custom_components/neovolt`
- exercised the added control paths against a live installation during local testing