### PR TITLE
Add Dynamic SOC Export mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This integration connects your Neovolt inverter to Home Assistant, giving you:
 
 - **Real-time monitoring** of solar production, battery status, and grid usage
 - **Full battery control** via a single Dispatch Mode selector
-- **Dynamic Export and Dynamic Import modes** for automatic grid power management
+- **Dynamic Export, Dynamic Import, and Dynamic SOC Export modes** for automatic grid power management
 - **Energy tracking** for the Home Assistant Energy Dashboard
 - **Multi-inverter support** with combined sensors for parallel setups
 - **Automations** to optimise when your battery charges and discharges
@@ -187,6 +187,7 @@ All battery control flows through a single **Dispatch Mode** selector. Configure
 | **Force Discharge** | Discharges to load/grid at the configured power until the cutoff SOC is reached |
 | **Dynamic Export** | Continuously adjusts discharge to maintain grid export at the target level |
 | **Dynamic Import** | Continuously adjusts charging to maintain grid import at the target level |
+| **Dynamic SOC Export** | Paces a smooth discharge over the dispatch duration to land on a target end-of-window SOC; battery export tracks house load with a configurable buffer to prevent grid import |
 | **No Battery Charge** | Prevents all battery charging (from solar and grid). Will still discharge to loads if needed |
 | **Idle (No Dispatch)** | Halts all battery dispatch (charging + discharging) — inverter stays online but battery sits idle |
 
@@ -201,8 +202,10 @@ Set these before activating Force Charge, Force Discharge, or Dynamic modes.
 | **Dispatch Power** | 0.5 – max kW | Charge or discharge power (slider max reflects your configured system capacity) |
 | **Dispatch Duration** | 1 – 480 min | How long to run the dispatch command |
 | **Dispatch Charge Target SOC** | 10 – 100 % | Stop Force Charge when battery reaches this SOC |
-| **Dispatch Discharge Cutoff SOC** | 4 – 100 % | Stop Force Discharge when battery falls to this SOC |
+| **Dispatch Discharge Cutoff SOC** | 4 – 100 % | Stop Force Discharge when battery falls to this SOC. Also acts as a hard floor in Dynamic SOC Export |
 | **Dynamic Mode Power Target** | 0.05 – 15 kW | Target export power (Dynamic Export) or target import power (Dynamic Import) |
+| **Dispatch Discharge Target SOC** | 4 – 100 % | Dynamic SOC Export only — desired battery SOC at the end of the dispatch window |
+| **Dispatch Discharge Export Buffer** | 0 – max kW | Dynamic SOC Export only — safety margin held above house load so battery export never falls into grid import (default 0.2 kW) |
 
 #### How to Use Force Charge
 
@@ -228,6 +231,112 @@ Dynamic Import charges the battery from the grid while holding a target import l
 
 1. Set **Dynamic Mode Power Target** to the grid import power you want to maintain (e.g. 2 kW).
 2. Set **Dispatch Mode** → **Dynamic Import**.
+
+#### How to Use Dynamic SOC Export
+
+Dynamic SOC Export discharges the battery smoothly across the dispatch window so the SOC lands on your chosen target by the end of the window. Unlike Dynamic Export — where **you** pick the export power — here the discharge rate is **computed** from the remaining SOC delta and remaining time, then adjusted as house load changes so excess discharge during a spike is amortised across the rest of the window. That means the battery always covers at least the house load plus your safety buffer (so the grid stays in export, never import).
+
+Use it when you want to drain the battery to a known SOC by a known time (e.g. empty the battery to 30 % over the next 4 hours of an export tariff window) without manually tuning the discharge power as your starting SOC and load varies.
+
+
+1. Set **Dispatch Duration** to the length of the window (e.g. 240 minutes).
+2. Set **Dispatch Discharge Target SOC** to the SOC you want the battery to land on at the end of the window (e.g. 30 %).
+3. Set **Dispatch Discharge Cutoff SOC** to a hard floor — discharge stops here regardless of pacing (e.g. 20 %).
+4. Set **Dispatch Discharge Export Buffer** to the safety margin above house load you want to maintain (default 0.2 kW). Raise this if your load fluctuates rapidly and you see brief grid import.
+5. Set **Dispatch Mode** → **Dynamic SOC Export**.
+
+Notes:
+- If current SOC is already at or below the target, the loop will still hold the export buffer above house load (i.e. it will still avoid grid import).
+- Like Dynamic Export mode, Dispatch Discharge Cutoff SOC still acts as an absolute floor, and the force discharge mode will termination if the battery SOC reaches this level.
+- The control loop re-evaluates every 5 seconds and applies the same debounce and slew limits as Dynamic Export.
+- The mode ends automatically when the dispatch duration expires or the discharge cutoff SOC is reached.
+
+Below is suggested automation to set **Dispatch Duration**.  It allows for HA being restarted during the force discharge time window, and sets **Dispatch Duration** to the remaining time.
+
+Variables at the bottom set the "Force Charge" and "Dynamic SOC Export" time windows as well as other parameters. This example assumes your device is named "home" and entity ids are like "number.neovolt_home_dispatch_power".
+
+```
+alias: Neovolt Time of Day Dispatch
+triggers:
+  - minutes: /5
+    trigger: time_pattern
+  - event: start
+    trigger: homeassistant
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ today_at(force_charge_start) <= now() <
+              today_at(force_charge_end) }}
+        sequence:
+          - action: number.set_value
+            target:
+              entity_id: number.neovolt_home_dispatch_power
+            data:
+              value: "{{ force_charge_power_kw }}"
+          - action: number.set_value
+            target:
+              entity_id: number.neovolt_home_dispatch_charge_target_soc
+            data:
+              value: "{{ force_charge_target_soc }}"
+          - action: number.set_value
+            target:
+              entity_id: number.neovolt_home_dispatch_duration
+            data:
+              value: >
+                {% set mins = ((today_at(force_charge_end) -
+                now()).total_seconds() / 60) | int %} {{ [mins, 1] | max }}
+          - action: select.select_option
+            target:
+              entity_id: select.neovolt_home_dispatch_mode
+            data:
+              option: Force Charge
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ today_at(dynamic_export_start) <= now() <
+              today_at(dynamic_export_end) }}
+        sequence:
+          - action: number.set_value
+            target:
+              entity_id: number.neovolt_home_dispatch_discharge_export_buffer
+            data:
+              value: "{{ dynamic_export_buffer_kw }}"
+          - action: number.set_value
+            target:
+              entity_id: number.neovolt_home_dispatch_discharge_target_soc
+            data:
+              value: "{{ dynamic_export_target_soc }}"
+          - action: number.set_value
+            target:
+              entity_id: number.neovolt_home_dispatch_duration
+            data:
+              value: >
+                {% set mins = ((today_at(dynamic_export_end) -
+                now()).total_seconds() / 60) | int %} {{ [mins, 1] | max }}
+          - action: select.select_option
+            target:
+              entity_id: select.neovolt_home_dispatch_mode
+            data:
+              option: Dynamic SOC Export
+    default:
+      - action: select.select_option
+        target:
+          entity_id: select.neovolt_home_dispatch_mode
+        data:
+          option: Normal
+mode: single
+variables:
+  force_charge_start: "11:00:00"
+  force_charge_end: "14:00:00"
+  force_charge_power_kw: 5
+  force_charge_target_soc: 80
+  dynamic_export_start: "18:00:00"
+  dynamic_export_end: "21:00:00"
+  dynamic_export_buffer_kw: 0.2
+  dynamic_export_target_soc: 47
+```
 
 #### Additional Controls
 

--- a/custom_components/neovolt/__init__.py
+++ b/custom_components/neovolt/__init__.py
@@ -196,6 +196,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 except Exception as e:
                     _LOGGER.debug(f"Error stopping Dynamic Import manager (ignored): {e}")
 
+            # Stop dynamic SOC export manager if running
+            if coordinator and hasattr(coordinator, 'dynamic_soc_export_manager'):
+                try:
+                    await coordinator.dynamic_soc_export_manager.stop()
+                    _LOGGER.info("Stopped Dynamic SOC Export manager during unload")
+                except Exception as e:
+                    _LOGGER.debug(f"Error stopping Dynamic SOC Export manager (ignored): {e}")
+
             # Close Modbus connection
             client = hass.data[DOMAIN][entry.entry_id].get("client")
             if client:

--- a/custom_components/neovolt/button.py
+++ b/custom_components/neovolt/button.py
@@ -87,6 +87,14 @@ class NeovoltStopForceChargeDischargeButton(CoordinatorEntity, ButtonEntity):
                 except Exception as e:
                     _LOGGER.debug(f"Dynamic Import manager not running or already stopped: {e}")
 
+            # Stop dynamic SOC export manager if running
+            if hasattr(self.coordinator, 'dynamic_soc_export_manager'):
+                try:
+                    await self.coordinator.dynamic_soc_export_manager.stop()
+                    _LOGGER.info("Stopped Dynamic SOC Export manager")
+                except Exception as e:
+                    _LOGGER.debug(f"Dynamic SOC Export manager not running or already stopped: {e}")
+
             await self._hass.async_add_executor_job(
                 self._client.write_registers, 0x0880, DISPATCH_RESET_VALUES
             )

--- a/custom_components/neovolt/const.py
+++ b/custom_components/neovolt/const.py
@@ -66,6 +66,13 @@ DISPATCH_MODE_NO_CHARGE = 19       # Mode 19: Prevent all battery charging (sola
 DISPATCH_MODE_DYNAMIC_EXPORT = 99   # Dynamic Export  (hardware: Mode 2 + calculated power)
 DISPATCH_MODE_DYNAMIC_IMPORT = 98   # Dynamic Import  (hardware: Mode 2 + calculated power)
 DISPATCH_MODE_NO_DISCHARGE = 97     # No Battery Discharge (hardware: Mode 2 + zero power)
+DISPATCH_MODE_DYNAMIC_SOC_EXPORT = 96  # Dynamic SOC Export (hardware: Mode 2 + smooth-rate power)
+
+# Dynamic SOC Export defaults
+DYNAMIC_SOC_EXPORT_DEFAULT_TARGET_SOC = 40  # %  end-of-window target SOC target
+DYNAMIC_SOC_EXPORT_DEFAULT_BUFFER = 0.2     # kW  export safety buffer to prevent import
+DYNAMIC_SOC_EXPORT_MIN_BUFFER = 0           # kW
+DYNAMIC_SOC_EXPORT_MAX_BUFFER = DEFAULT_MAX_DISCHARGE_POWER # kW
 
 # Dispatch command duration default (seconds)
 # Used when resetting dispatch - maintains previous command for 90 seconds

--- a/custom_components/neovolt/coordinator.py
+++ b/custom_components/neovolt/coordinator.py
@@ -959,6 +959,7 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
         from .const import (
             DISPATCH_MODE_DYNAMIC_EXPORT,
             DISPATCH_MODE_DYNAMIC_IMPORT,
+            DISPATCH_MODE_DYNAMIC_SOC_EXPORT,
             DISPATCH_MODE_NO_DISCHARGE,
         )
 
@@ -977,6 +978,10 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
         dynamic_import_running = (
             hasattr(self, "dynamic_import_manager")
             and self.dynamic_import_manager.is_running
+        )
+        dynamic_soc_export_running = (
+            hasattr(self, "dynamic_soc_export_manager")
+            and self.dynamic_soc_export_manager.is_running
         )
 
         # Check if No Battery Discharge is currently the cached mode.
@@ -1003,6 +1008,8 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
 
         if dynamic_import_running:
             effective_mode = DISPATCH_MODE_DYNAMIC_IMPORT
+        elif dynamic_soc_export_running:
+            effective_mode = DISPATCH_MODE_DYNAMIC_SOC_EXPORT
         elif dynamic_export_running:
             effective_mode = DISPATCH_MODE_DYNAMIC_EXPORT
         elif no_discharge_active:

--- a/custom_components/neovolt/coordinator.py
+++ b/custom_components/neovolt/coordinator.py
@@ -1448,6 +1448,7 @@ class NeovoltDataUpdateCoordinator(DataUpdateCoordinator):
             dynamic_running = (
                 (hasattr(self, "dynamic_export_manager") and self.dynamic_export_manager.is_running)
                 or (hasattr(self, "dynamic_import_manager") and self.dynamic_import_manager.is_running)
+                or (hasattr(self, "dynamic_soc_export_manager") and self.dynamic_soc_export_manager.is_running)
             )
             if not dynamic_running:
                 _LOGGER.debug(

--- a/custom_components/neovolt/dynamic_export.py
+++ b/custom_components/neovolt/dynamic_export.py
@@ -421,11 +421,9 @@ class DynamicExportManager:
 
         Base implementation reads the static "Dynamic Mode Power Target" entity.
         Subclasses override to compute a dynamic setpoint.
-        """    
-        # Get target export from number entity (unique_id lookup — robust to device naming)
-        return  safe_get_by_unique_id(
+        """
+        return _safe_get_by_unique_id(
             self._hass,
-            f"number.neovolt_{self._device_name}_dynamic_mode_power_target",
             f"neovolt_{self._device_name}_dynamic_mode_power_target",
             1.0,
         )

--- a/custom_components/neovolt/dynamic_export.py
+++ b/custom_components/neovolt/dynamic_export.py
@@ -24,18 +24,23 @@ from .const import (
     DEFAULT_MAX_CHARGE_POWER,
     DISPATCH_MODE_DYNAMIC_EXPORT,
     DISPATCH_MODE_DYNAMIC_IMPORT,
+    DISPATCH_MODE_DYNAMIC_SOC_EXPORT,
     DISPATCH_MODE_POWER_WITH_SOC,
     DYNAMIC_EXPORT_MIN_POWER,
     DYNAMIC_EXPORT_UPDATE_INTERVAL,
     DYNAMIC_EXPORT_SETTLE_SECONDS,
     DYNAMIC_EXPORT_MAX_STEP_KW,
     DYNAMIC_MODE_FAST_POLL_INTERVAL,
+    DYNAMIC_SOC_EXPORT_DEFAULT_TARGET_SOC,
+    DYNAMIC_SOC_EXPORT_DEFAULT_BUFFER,
     MODBUS_OFFSET,
     SOC_CONVERSION_FACTOR,
     MAX_SOC_REGISTER,
     MIN_SOC_REGISTER,
     COMBINED_BATTERY_SOC,
     COMBINED_BATTERY_POWER,
+    COMBINED_BATTERY_CAPACITY,
+    COMBINED_HOUSE_LOAD,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,6 +106,11 @@ def soc_percent_to_register(soc_percent: float) -> int:
 
 class DynamicExportManager:
     """Manages Dynamic Export mode - continuous adjustment of battery discharge/charge."""
+
+    # Internal tracking mode tag stamped onto coordinator data for current_option detection.
+    # Subclasses (e.g. DynamicSOCExportManager) override to distinguish themselves while
+    # reusing the underlying control loop and command builders.
+    _dispatch_mode_tag = DISPATCH_MODE_DYNAMIC_EXPORT
 
     def __init__(
         self,
@@ -285,12 +295,9 @@ class DynamicExportManager:
         """
         data = self._coordinator.data
 
-        # Get target export from number entity (unique_id lookup — robust to device naming)
-        target_export_kw = _safe_get_by_unique_id(
-            self._hass,
-            f"neovolt_{self._device_name}_dynamic_mode_power_target",
-            1.0,
-        )
+        # Get target export — subclasses override _get_target_export_kw() to compute
+        # this dynamically (e.g. SOC-paced smooth rate). Base class reads the entity.
+        target_export_kw = self._get_target_export_kw()
 
         # Get discharge SOC cutoff (unique_id lookup — robust to device naming)
         soc_cutoff = int(_safe_get_by_unique_id(
@@ -409,6 +416,20 @@ class DynamicExportManager:
 
         self._last_update_time = now
 
+    def _get_target_export_kw(self) -> float:
+        """Return the desired net grid export setpoint (kW) for this cycle.
+
+        Base implementation reads the static "Dynamic Mode Power Target" entity.
+        Subclasses override to compute a dynamic setpoint.
+        """    
+        # Get target export from number entity (unique_id lookup — robust to device naming)
+        return  safe_get_by_unique_id(
+            self._hass,
+            f"number.neovolt_{self._device_name}_dynamic_mode_power_target",
+            f"neovolt_{self._device_name}_dynamic_mode_power_target",
+            1.0,
+        )
+
     async def _send_discharge_command(self, power_kw: float, soc_cutoff: int) -> None:
         """Send force discharge command to inverter.
 
@@ -445,7 +466,7 @@ class DynamicExportManager:
             # Update coordinator with optimistic values
             self._coordinator.set_optimistic_value("dispatch_start", 1)
             self._coordinator.set_optimistic_value("dispatch_power", power_watts)
-            self._coordinator.set_optimistic_value("dispatch_mode", DISPATCH_MODE_DYNAMIC_EXPORT)
+            self._coordinator.set_optimistic_value("dispatch_mode", self._dispatch_mode_tag)
 
         except Exception as e:
             _LOGGER.error(f"Failed to send Dynamic Export discharge command: {e}")
@@ -487,7 +508,7 @@ class DynamicExportManager:
             # Update coordinator with optimistic values
             self._coordinator.set_optimistic_value("dispatch_start", 1)
             self._coordinator.set_optimistic_value("dispatch_power", -power_watts)
-            self._coordinator.set_optimistic_value("dispatch_mode", DISPATCH_MODE_DYNAMIC_EXPORT)
+            self._coordinator.set_optimistic_value("dispatch_mode", self._dispatch_mode_tag)
 
         except Exception as e:
             _LOGGER.error(f"Failed to send Dynamic Export charge command: {e}")
@@ -523,7 +544,7 @@ class DynamicExportManager:
             # Update coordinator with optimistic values
             self._coordinator.set_optimistic_value("dispatch_start", 1)
             self._coordinator.set_optimistic_value("dispatch_power", 0)
-            self._coordinator.set_optimistic_value("dispatch_mode", DISPATCH_MODE_DYNAMIC_EXPORT)
+            self._coordinator.set_optimistic_value("dispatch_mode", self._dispatch_mode_tag)
 
         except Exception as e:
             _LOGGER.error(f"Failed to send Dynamic Export standby command: {e}")
@@ -549,6 +570,108 @@ class DynamicExportManager:
             
         except Exception as e:
             _LOGGER.error(f"Failed to stop Dynamic Export dispatch: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Dynamic SOC Export Manager
+# ---------------------------------------------------------------------------
+
+class DynamicSOCExportManager(DynamicExportManager):
+    """Dynamic SOC Export — smooth discharge to a target SOC across a window.
+
+    Behaviour:
+      * Each cycle, compute the smooth discharge rate needed to reach the target
+        SOC by the end of the discharge window:
+
+            smooth_rate_kw = (current_soc - target_soc)% × capacity_kWh / remaining_hours
+
+      * To never import, the battery instead discharges at:
+
+            battery_discharge_kw = max(smooth_rate_kw, house_load_kw + safety_buffer_kw)
+
+        Equivalently, the grid export setpoint passed to the closed loop is:
+
+            target_export_kw = max(smooth_rate_kw - house_load_kw, safety_buffer_kw)
+
+      * When house load drops, the smooth rate is recomputed against the new
+        (lower) remaining SOC and the (smaller) remaining time — so any excess
+        discharged during a spike is naturally amortised across the rest of the
+        window.
+
+    The hard discharge cutoff (Dispatch Discharge Cutoff SOC) still applies as a
+    floor — once reached, the loop sends standby commands and Para5 enforces
+    the floor at the inverter.
+    """
+
+    _dispatch_mode_tag = DISPATCH_MODE_DYNAMIC_SOC_EXPORT
+
+    def _get_target_export_kw(self) -> float:
+        """Compute the export setpoint from SOC pacing and house load."""
+        data = self._coordinator.data
+
+        # ── Read user inputs ─────────────────────────────────────────────────
+        target_soc = _safe_get_by_unique_id(
+            self._hass,
+            f"neovolt_{self._device_name}_dispatch_discharge_target_soc",
+            float(DYNAMIC_SOC_EXPORT_DEFAULT_TARGET_SOC),
+        )
+        buffer_kw = _safe_get_by_unique_id(
+            self._hass,
+            f"neovolt_{self._device_name}_dispatch_discharge_export_buffer",
+            float(DYNAMIC_SOC_EXPORT_DEFAULT_BUFFER),
+        )
+
+        # ── Remaining time in window ─────────────────────────────────────────
+        # Floor at 1 minute so the smooth rate doesn't blow up in the final
+        # seconds; once the window elapses the control loop ends the mode anyway.
+        if self._start_time and self._duration_minutes:
+            elapsed_s = (dt_util.now() - self._start_time).total_seconds()
+            remaining_s = self._duration_minutes * 60.0 - elapsed_s
+            remaining_hours = max(remaining_s / 3600.0, 1.0 / 60.0)
+        else:
+            remaining_hours = 1.0
+
+        # ── Current SOC ──────────────────────────────────────────────────────
+        current_soc = data.get(COMBINED_BATTERY_SOC) or data.get("battery_soc")
+        if current_soc is None:
+            _LOGGER.warning(
+                "Dynamic SOC Export: current SOC unavailable, falling back to buffer only"
+            )
+            return buffer_kw
+
+        # ── Battery capacity (kWh) ───────────────────────────────────────────
+        capacity_kwh = (
+            data.get(COMBINED_BATTERY_CAPACITY)
+            or data.get("battery_capacity")
+            or 20.1
+        )
+
+        # ── Smooth rate ──────────────────────────────────────────────────────
+        soc_delta_pct = max(0.0, current_soc - target_soc)
+        energy_to_discharge_kwh = (soc_delta_pct / 100.0) * capacity_kwh
+        smooth_rate_kw = energy_to_discharge_kwh / remaining_hours
+
+        # ── House load (W → kW) ──────────────────────────────────────────────
+        house_load_w = (
+            data.get(COMBINED_HOUSE_LOAD)
+            or data.get("total_house_load")
+            or 0
+        )
+        house_load_kw = house_load_w / 1000.0
+
+        # ── Target grid export setpoint ──────────────────────────────────────
+        # Battery discharge = max(smooth_rate, house_load + buffer)
+        #   ⇒ grid export = battery_discharge − house_load
+        #                 = max(smooth_rate − house_load, buffer)
+        target_export_kw = max(smooth_rate_kw - house_load_kw, buffer_kw)
+
+        _LOGGER.debug(
+            f"Dynamic SOC Export: SOC {current_soc:.1f}%→{target_soc:.0f}%, "
+            f"remaining={remaining_hours * 60:.1f}min, capacity={capacity_kwh:.1f}kWh, "
+            f"smooth_rate={smooth_rate_kw:.2f}kW, load={house_load_kw:.2f}kW, "
+            f"buffer={buffer_kw:.2f}kW → target_export={target_export_kw:.2f}kW"
+        )
+        return target_export_kw
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/neovolt/number.py
+++ b/custom_components/neovolt/number.py
@@ -20,6 +20,10 @@ from .const import (
     DEFAULT_DYNAMIC_EXPORT_TARGET,
     DYNAMIC_EXPORT_MIN_POWER,
     DYNAMIC_EXPORT_MAX_POWER,
+    DYNAMIC_SOC_EXPORT_DEFAULT_TARGET_SOC,
+    DYNAMIC_SOC_EXPORT_DEFAULT_BUFFER,
+    DYNAMIC_SOC_EXPORT_MIN_BUFFER,
+    DYNAMIC_SOC_EXPORT_MAX_BUFFER,
     DEVICE_ROLE_FOLLOWER,
     GRID_POWER_OFFSET_MIN,
     GRID_POWER_OFFSET_MAX,
@@ -117,6 +121,26 @@ async def async_setup_entry(
             DYNAMIC_EXPORT_MIN_POWER, DYNAMIC_EXPORT_MAX_POWER, 0.05, UnitOfPower.KILO_WATT, None, False,
             default_value=DEFAULT_DYNAMIC_EXPORT_TARGET, icon="mdi:transmission-tower-export",
             config_entry=entry, fixed_max=True
+        ),
+
+        # ── Dynamic SOC Export (local storage) ─────────────────────────────
+        # End-of-window SOC target the smooth-rate calculation paces towards.
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "dispatch_discharge_target_soc", "Dispatch Discharge Target SOC",
+            4, 100, 1, PERCENTAGE, None, False,
+            default_value=DYNAMIC_SOC_EXPORT_DEFAULT_TARGET_SOC,
+            icon="mdi:battery-heart-variant",
+        ),
+        # Safety buffer (W) that the battery exports above house load whenever
+        # the smooth rate alone would otherwise allow grid import.
+        NeovoltNumber(
+            coordinator, device_info, device_name, client, hass,
+            "dispatch_discharge_export_buffer", "Dispatch Discharge Export Buffer",
+            DYNAMIC_SOC_EXPORT_MIN_BUFFER, DYNAMIC_SOC_EXPORT_MAX_BUFFER, 0.1,
+            UnitOfPower.KILO_WATT, None, False,
+            default_value=DYNAMIC_SOC_EXPORT_DEFAULT_BUFFER,
+            icon="mdi:shield-bug",
         ),
 
         # ── PV Capacity (32-bit register, in Watts) ────────────────────────

--- a/custom_components/neovolt/select.py
+++ b/custom_components/neovolt/select.py
@@ -607,6 +607,19 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
             manager = getattr(self.coordinator, attr, None)
             if manager is not None:
                 await manager.stop()
+        # Clear any prior watcher intent — will be re-armed at end of this method
+        self.coordinator.soc_watcher_disarm()
+
+        # Persist the current discharge cutoff so the watcher uses the correct
+        # value here and after a HA restart (the startup rearm logic reads
+        # self._dispatch_discharge_soc, not the entity).
+        _soc_cutoff, _, _ = safe_get_by_unique_id(
+            self._hass,
+            f"neovolt_{self._device_name}_dispatch_discharge_soc",
+            10.0,
+        )
+        self.coordinator._dispatch_discharge_soc = float(int(_soc_cutoff))
+        self.coordinator._save_persistent_data()
 
         if not hasattr(self.coordinator, "dynamic_soc_export_manager"):
             from .dynamic_export import DynamicSOCExportManager
@@ -624,6 +637,9 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
 
         self.coordinator.set_optimistic_value("dispatch_start", 1)
         self.coordinator.set_optimistic_value("dispatch_mode", DISPATCH_MODE_DYNAMIC_SOC_EXPORT)
+        # Arm the SOC watcher for discharge direction — enforces the hard cutoff
+        # floor regardless of whether the manager itself is still running.
+        self.coordinator.soc_watcher_arm("discharge")
         await self.coordinator.async_request_refresh()
 
     async def _start_no_battery_charge(self):

--- a/custom_components/neovolt/select.py
+++ b/custom_components/neovolt/select.py
@@ -15,6 +15,7 @@ from .const import (
     DISPATCH_MODE_POWER_WITH_SOC,
     DISPATCH_MODE_DYNAMIC_EXPORT,
     DISPATCH_MODE_DYNAMIC_IMPORT,
+    DISPATCH_MODE_DYNAMIC_SOC_EXPORT,
     DISPATCH_MODE_NO_CHARGE,
     DISPATCH_MODE_NO_DISCHARGE,
     DISPATCH_RESET_VALUES,
@@ -227,6 +228,7 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         "Force Discharge",
         "Dynamic Export",
         "Dynamic Import",
+        "Dynamic SOC Export",
         "No Battery Charge",
         "Idle (No Dispatch)",
     ]
@@ -268,6 +270,9 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         if dispatch_mode == DISPATCH_MODE_DYNAMIC_IMPORT:
             return "Dynamic Import"
 
+        if dispatch_mode == DISPATCH_MODE_DYNAMIC_SOC_EXPORT:
+            return "Dynamic SOC Export"
+
         if dispatch_mode == DISPATCH_MODE_NO_DISCHARGE:
             return "Idle (No Dispatch)"
 
@@ -298,6 +303,8 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
                 await self._start_dynamic_export()
             elif option == "Dynamic Import":
                 await self._start_dynamic_import()
+            elif option == "Dynamic SOC Export":
+                await self._start_dynamic_soc_export()
             elif option == "No Battery Charge":
                 await self._start_no_battery_charge()
             elif option == "Idle (No Dispatch)":
@@ -308,13 +315,20 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         except Exception as e:
             _LOGGER.error(f"Failed to set dispatch mode to '{option}': {e}", exc_info=True)
 
+    async def _stop_all_dynamic_managers(self):
+        """Stop every dynamic dispatch manager that is currently attached."""
+        for attr in (
+            "dynamic_export_manager",
+            "dynamic_import_manager",
+            "dynamic_soc_export_manager",
+        ):
+            manager = getattr(self.coordinator, attr, None)
+            if manager is not None:
+                await manager.stop()
+
     async def _stop_dispatch(self):
         """Stop all active dispatch modes (Normal mode)."""
-        # Stop dynamic export/import if running
-        if hasattr(self.coordinator, 'dynamic_export_manager'):
-            await self.coordinator.dynamic_export_manager.stop()
-        if hasattr(self.coordinator, 'dynamic_import_manager'):
-            await self.coordinator.dynamic_import_manager.stop()
+        await self._stop_all_dynamic_managers()
 
         _LOGGER.info("Stopping dispatch, returning to Normal mode")
         await self._hass.async_add_executor_job(
@@ -329,10 +343,7 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
     async def _start_force_charge(self):
         """Start force charging with parameters from number entities."""
         # Stop dynamic export/import if running
-        if hasattr(self.coordinator, 'dynamic_export_manager'):
-            await self.coordinator.dynamic_export_manager.stop()
-        if hasattr(self.coordinator, 'dynamic_import_manager'):
-            await self.coordinator.dynamic_import_manager.stop()
+        await self._stop_all_dynamic_managers()
         # Clear any prior intent (will be re-set at end of this method)
         self.coordinator.soc_watcher_disarm()
 
@@ -341,6 +352,7 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
             f"neovolt_{self._device_name}_dispatch_power",
             3.0
         )
+
         _duration, duration_default, duration_reason = safe_get_by_unique_id(
             self._hass,
             f"neovolt_{self._device_name}_dispatch_duration",
@@ -422,10 +434,7 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
     async def _start_force_discharge(self):
         """Start force discharging with parameters from number entities."""
         # Stop dynamic export/import if running
-        if hasattr(self.coordinator, 'dynamic_export_manager'):
-            await self.coordinator.dynamic_export_manager.stop()
-        if hasattr(self.coordinator, 'dynamic_import_manager'):
-            await self.coordinator.dynamic_import_manager.stop()
+        await self._stop_all_dynamic_managers()
         # Clear any prior intent (will be re-set at end of this method)
         self.coordinator.soc_watcher_disarm()
 
@@ -516,9 +525,11 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         """Start Dynamic Export mode - discharge at load + target kW."""
         _LOGGER.info("Starting Dynamic Export mode")
 
-        # Stop dynamic import if running
-        if hasattr(self.coordinator, 'dynamic_import_manager'):
-            await self.coordinator.dynamic_import_manager.stop()
+        # Stop any other dynamic manager that may be running
+        for attr in ("dynamic_import_manager", "dynamic_soc_export_manager"):
+            manager = getattr(self.coordinator, attr, None)
+            if manager is not None:
+                await manager.stop()
         # Clear any force charge/discharge intent — dynamic modes manage their own SOC guards
         self.coordinator.soc_watcher_disarm()
 
@@ -549,9 +560,11 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         """Start Dynamic Import mode - charge battery to maintain target grid import level."""
         _LOGGER.info("Starting Dynamic Import mode")
 
-        # Stop dynamic export if running
-        if hasattr(self.coordinator, 'dynamic_export_manager'):
-            await self.coordinator.dynamic_export_manager.stop()
+        # Stop any other dynamic manager that may be running
+        for attr in ("dynamic_export_manager", "dynamic_soc_export_manager"):
+            manager = getattr(self.coordinator, attr, None)
+            if manager is not None:
+                await manager.stop()
         # Clear any force charge/discharge intent — dynamic modes manage their own SOC guards
         self.coordinator.soc_watcher_disarm()
 
@@ -578,13 +591,44 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         self.coordinator.soc_watcher_arm("charge")
         await self.coordinator.async_request_refresh()
 
+    async def _start_dynamic_soc_export(self):
+        """Start Dynamic SOC Export mode — smooth discharge to a target end-of-window SOC.
+
+        Reads:
+          * Dispatch Duration              — window length (minutes)
+          * Dispatch Discharge Target SOC            — desired SOC at window end (%)
+          * Dispatch Discharge Cutoff SOC  — hard floor, never discharge below
+          * Dispatch Discharge Export Buffer         — safety margin to ensure no grid import (W)
+        """
+        _LOGGER.info("Starting Dynamic SOC Export mode")
+
+        # Stop any other dynamic manager that may be running
+        for attr in ("dynamic_export_manager", "dynamic_import_manager"):
+            manager = getattr(self.coordinator, attr, None)
+            if manager is not None:
+                await manager.stop()
+
+        if not hasattr(self.coordinator, "dynamic_soc_export_manager"):
+            from .dynamic_export import DynamicSOCExportManager
+            self.coordinator.dynamic_soc_export_manager = DynamicSOCExportManager(
+                self._hass, self.coordinator, self._client, self._device_name
+            )
+            _LOGGER.debug("Created new Dynamic SOC Export manager instance")
+
+        try:
+            await self.coordinator.dynamic_soc_export_manager.start()
+            _LOGGER.info("Dynamic SOC Export manager started successfully")
+        except Exception as e:
+            _LOGGER.error(f"Failed to start Dynamic SOC Export manager: {e}", exc_info=True)
+            return
+
+        self.coordinator.set_optimistic_value("dispatch_start", 1)
+        self.coordinator.set_optimistic_value("dispatch_mode", DISPATCH_MODE_DYNAMIC_SOC_EXPORT)
+        await self.coordinator.async_request_refresh()
+
     async def _start_no_battery_charge(self):
         """Mode 19: Prevent all battery charging (solar & grid)."""
-        # Stop dynamic export/import if running
-        if hasattr(self.coordinator, 'dynamic_export_manager'):
-            await self.coordinator.dynamic_export_manager.stop()
-        if hasattr(self.coordinator, 'dynamic_import_manager'):
-            await self.coordinator.dynamic_import_manager.stop()
+        await self._stop_all_dynamic_managers()
         self.coordinator.soc_watcher_disarm()
 
         _duration, duration_default, duration_reason = safe_get_by_unique_id(
@@ -640,11 +684,7 @@ class NeovoltDispatchModeSelect(CoordinatorEntity, SelectEntity):
         NOTE: Hardware Mode 20 was tested and found to trigger full-rate Force Charge
         on this firmware. It is intentionally NOT used here.
         """
-        # Stop dynamic export/import if running
-        if hasattr(self.coordinator, 'dynamic_export_manager'):
-            await self.coordinator.dynamic_export_manager.stop()
-        if hasattr(self.coordinator, 'dynamic_import_manager'):
-            await self.coordinator.dynamic_import_manager.stop()
+        await self._stop_all_dynamic_managers()
         self.coordinator.soc_watcher_disarm()
 
         _duration, duration_default, duration_reason = safe_get_by_unique_id(

--- a/custom_components/neovolt/sensor.py
+++ b/custom_components/neovolt/sensor.py
@@ -603,7 +603,12 @@ class NeovoltDispatchStatusSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return human-readable dispatch status."""
-        from .const import DISPATCH_MODE_DYNAMIC_EXPORT, DISPATCH_MODE_DYNAMIC_IMPORT, DISPATCH_MODE_NO_DISCHARGE
+        from .const import (
+            DISPATCH_MODE_DYNAMIC_EXPORT,
+            DISPATCH_MODE_DYNAMIC_IMPORT,
+            DISPATCH_MODE_DYNAMIC_SOC_EXPORT,
+            DISPATCH_MODE_NO_DISCHARGE,
+        )
 
         data = self.coordinator.data
         dispatch_start = data.get("dispatch_start", 0)
@@ -668,6 +673,27 @@ class NeovoltDispatchStatusSensor(CoordinatorEntity, SensorEntity):
                     remaining_minutes = max(0, manager._duration_minutes - elapsed_minutes)
                     dispatch_time = int(remaining_minutes * 60)  # Convert to seconds
 
+        elif dispatch_mode == DISPATCH_MODE_DYNAMIC_SOC_EXPORT:
+            try:
+                from .select import safe_get_entity_float
+                target_soc = safe_get_entity_float(
+                    self.hass,
+                    f"number.neovolt_{self._device_name}_dispatch_discharge_target_soc",
+                    40.0,
+                )
+                mode = f"Dynamic SOC Export (target {target_soc:.0f}%)"
+                power_kw = abs(dispatch_power) / 1000 if dispatch_power else None
+            except Exception:
+                mode = "Dynamic SOC Export"
+                power_kw = abs(dispatch_power) / 1000 if dispatch_power else None
+
+            if hasattr(self.coordinator, 'dynamic_soc_export_manager'):
+                manager = self.coordinator.dynamic_soc_export_manager
+                if manager.is_running and manager._start_time and manager._duration_minutes:
+                    elapsed_minutes = (dt_util.now() - manager._start_time).total_seconds() / 60.0
+                    remaining_minutes = max(0, manager._duration_minutes - elapsed_minutes)
+                    dispatch_time = int(remaining_minutes * 60)
+
         elif dispatch_mode == 1:
             mode = "Battery PV Only"
         elif dispatch_mode == 3:
@@ -692,7 +718,12 @@ class NeovoltDispatchStatusSensor(CoordinatorEntity, SensorEntity):
             mode = f"Mode {dispatch_mode}"
 
         # Build status string — suppress power display for dynamic/no-power modes
-        dynamic_modes = (DISPATCH_MODE_DYNAMIC_EXPORT, DISPATCH_MODE_DYNAMIC_IMPORT, DISPATCH_MODE_NO_DISCHARGE)
+        dynamic_modes = (
+            DISPATCH_MODE_DYNAMIC_EXPORT,
+            DISPATCH_MODE_DYNAMIC_IMPORT,
+            DISPATCH_MODE_DYNAMIC_SOC_EXPORT,
+            DISPATCH_MODE_NO_DISCHARGE,
+        )
         if power_kw and dispatch_mode not in dynamic_modes:
             status = f"{mode} @ {power_kw:.1f}kW"
         else:
@@ -712,7 +743,11 @@ class NeovoltDispatchStatusSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict:
         """Return detailed dispatch state as attributes."""
-        from .const import DISPATCH_MODE_DYNAMIC_EXPORT, DISPATCH_MODE_DYNAMIC_IMPORT
+        from .const import (
+            DISPATCH_MODE_DYNAMIC_EXPORT,
+            DISPATCH_MODE_DYNAMIC_IMPORT,
+            DISPATCH_MODE_DYNAMIC_SOC_EXPORT,
+        )
 
         data = self.coordinator.data
         attrs = {
@@ -736,6 +771,12 @@ class NeovoltDispatchStatusSensor(CoordinatorEntity, SensorEntity):
             attrs["dynamic_import_active"] = True
             if hasattr(self.coordinator, 'dynamic_import_manager'):
                 attrs["dynamic_import_running"] = self.coordinator.dynamic_import_manager.is_running
+
+        # Add Dynamic SOC Export specific attributes
+        elif current_mode == DISPATCH_MODE_DYNAMIC_SOC_EXPORT:
+            attrs["dynamic_soc_export_active"] = True
+            if hasattr(self.coordinator, 'dynamic_soc_export_manager'):
+                attrs["dynamic_soc_export_running"] = self.coordinator.dynamic_soc_export_manager.is_running
 
         return attrs
 

--- a/custom_components/neovolt/strings.json
+++ b/custom_components/neovolt/strings.json
@@ -109,6 +109,7 @@
           "force_discharge": "Force Discharge",
           "dynamic_export": "Dynamic Export",
           "dynamic_import": "Dynamic Import",
+          "dynamic_soc_export": "Dynamic SOC Export",
           "no_battery_charge": "No Battery Charge",
           "no_battery_discharge": "Idle (No Dispatch)"
         },
@@ -128,6 +129,9 @@
           "dynamic_import": {
             "description": "Automatically charge from the grid to maintain the target import power level. Continuously adjusts every 10 seconds with 0.3kW debounce threshold."
           },
+          "dynamic_soc_export": {
+            "description": "Smooth-paced discharge towards a target SOC at the end of the discharge window. If house load exceeds the smooth rate, discharge ramps up to cover load + safety buffer so the system never imports; when load drops, the smooth rate is recomputed from the remaining SOC and time so the SOC target still lands at window close."
+          },
           "no_battery_charge": {
             "description": "Prevent all battery charging (from solar and grid)"
           },
@@ -141,6 +145,14 @@
       "dynamic_mode_power_target": {
         "name": "Dynamic Mode Power Target",
         "description": "Target power level for dynamic dispatch modes (in kW).\n\nDynamic Export: battery discharges to export this amount above house load.\nDynamic Import: battery charges so that this amount is drawn from the grid.\n\nUpdates every 10 seconds with a 0.3kW debounce threshold."
+      },
+      "dispatch_discharge_target_soc": {
+        "name": "Dispatch Discharge Target SOC",
+        "description": "End-of-window SOC target (%) for Dynamic SOC Export mode. The smooth discharge rate is calculated from (current SOC − target SOC) × battery capacity ÷ remaining window time."
+      },
+      "dispatch_discharge_export_buffer": {
+        "name": "Dispatch Discharge Export Buffer",
+        "description": "Safety export buffer (W) for Dynamic SOC Export mode. The battery always discharges enough to keep the grid exporting at least this amount, preventing any grid import even when house load spikes above the smooth discharge rate."
       }
     },
     "button": {

--- a/custom_components/neovolt/translations/en.json
+++ b/custom_components/neovolt/translations/en.json
@@ -109,6 +109,7 @@
           "force_discharge": "Force Discharge",
           "dynamic_export": "Dynamic Export",
           "dynamic_import": "Dynamic Import",
+          "dynamic_soc_export": "Dynamic SOC Export",
           "no_battery_charge": "No Battery Charge",
           "no_battery_discharge": "Idle (No Dispatch)"
         }
@@ -117,6 +118,12 @@
     "number": {
       "dynamic_mode_power_target": {
         "name": "Dynamic Mode Power Target"
+      },
+      "dispatch_discharge_target_soc": {
+        "name": "Dispatch Discharge Target SOC"
+      },
+      "dispatch_discharge_export_buffer": {
+        "name": "Dispatch Discharge Export Buffer"
       }
     },
     "button": {


### PR DESCRIPTION
This is a different version of the existing Dynamic Export mode.

With Dynamic Export, the user chooses the grid export rate, and the battery discharge rate is continuously adjusted to equally grid export + load.

With Dynamic SOC Export, the user chooses a target SOC at the end of the discharge window.  The battery discharge rate is continuously adjusted to: At a minimum cover the house load plus an optional buffer (even if doing so will land below the target SOC) If any excess SOC is available, at a smoothed rate that targets the SOC reaching the set level at the end of the discharge window

This allows a better “set and forget” system.  On days where I’ve had heavy usage, or low solar charging, my battery will be at a lower SOC than usual going into the discharge window.  In that case, I want a lower grid export rate to ensure I can make it through to, say, 11AM the next morning (in my case, that’s when I have free grid import rates) without needing to grid import to support house load.

Dynamic Export requires me to think about and tweak the export rate daily.  Dynamic SOC Export allows me to just set a target of 45% SOC at the end of the discharge window (9pm for me) and not have to adjust day to day, or season to season.